### PR TITLE
Undefine module support

### DIFF
--- a/ext/duktape/duktape_ext.c
+++ b/ext/duktape/duktape_ext.c
@@ -34,6 +34,13 @@ static void ctx_dealloc(void *ctx)
 static VALUE ctx_alloc(VALUE klass)
 {
   duk_context *ctx = duk_create_heap(NULL, NULL, NULL, NULL, error_handler);
+
+  // Undefine require property
+  duk_push_global_object(ctx);
+  duk_push_string(ctx, "require");
+  duk_del_prop(ctx, -2);
+  duk_set_top(ctx, 0);
+
   return Data_Wrap_Struct(klass, NULL, ctx_dealloc, ctx);
 }
 

--- a/test/test_duktape.rb
+++ b/test/test_duktape.rb
@@ -132,6 +132,23 @@ class TestDuktape < Minitest::Spec
     assert_includes res, "#{__FILE__}:3"
   end
 
+  describe "modules" do
+    def test_required_undefined
+      assert_equal 'undefined',
+        @ctx.eval_string('typeof require', __FILE__)
+    end
+
+    def test_module_undefined
+      assert_equal 'undefined',
+        @ctx.eval_string('typeof module', __FILE__)
+    end
+
+    def test_exports_undefined
+      assert_equal 'undefined',
+        @ctx.eval_string('typeof exports', __FILE__)
+    end
+  end
+
   ## Previous bugs in Duktape
   describe "previous bugs" do
     def test_tailcall_bug


### PR DESCRIPTION
Duktape has some shims for CJS style modules. However, its pretty useless in the context of this extension since you still need to write some c code to tell the module loader how to read files from disk. That leaves a broken `require` as global function. Its typical for JS libraries to test for `require` and `module` and change behavior in a CJS environment.

It might be interesting to implement the module loader stuff someday, but for now I think we should just remove them and normalize the default context.
