### PR TITLE
Encodings

### DIFF
--- a/ext/duktape/duktape_ext.c
+++ b/ext/duktape/duktape_ext.c
@@ -161,6 +161,7 @@ static VALUE ctx_stack_to_value(duk_context *ctx, int index)
 static void ctx_push_ruby_object(duk_context *ctx, VALUE obj)
 {
   duk_idx_t arr_idx;
+  VALUE str;
 
   switch (TYPE(obj)) {
     case T_FIXNUM:
@@ -172,7 +173,8 @@ static void ctx_push_ruby_object(duk_context *ctx, VALUE obj)
       return;
 
     case T_STRING:
-      duk_push_lstring(ctx, RSTRING_PTR(obj), RSTRING_LEN(obj));
+      str = rb_str_conv_enc(obj, rb_enc_get(obj), rb_utf8_encoding());
+      duk_push_lstring(ctx, RSTRING_PTR(str), RSTRING_LEN(str));
       return;
 
     case T_TRUE:

--- a/test/test_duktape.rb
+++ b/test/test_duktape.rb
@@ -186,7 +186,18 @@ class TestDuktape < Minitest::Spec
 
   describe "string encoding" do
     def test_string_utf8_encoding
-      assert_equal Encoding::UTF_8, @ctx.eval_string('"foo"', __FILE__).encoding
+      str = @ctx.eval_string('"foo"', __FILE__)
+      assert_equal 'foo', str
+      assert_equal Encoding::UTF_8, str.encoding
+    end
+
+    def test_arguments_are_transcoded_to_utf8
+      @ctx.eval_string('function id(a) { return a }', __FILE__)
+      # "foo" as UTF-16LE bytes
+      str = "\x66\x00\x6f\x00\x6f\00".force_encoding(Encoding::UTF_16LE)
+      str = @ctx.call_prop('id', str)
+      assert_equal 'foo', str
+      assert_equal Encoding::UTF_8, str.encoding
     end
   end
 


### PR DESCRIPTION
We need to decide on an encoding policy. Right now all the returned strings are untagged.

> In Duktape, Ecmascript strings are encoded with CESU-8 encoding. CESU-8 matches UTF-8 except that it allows codepoints in the surrogate pair range (U+D800 to U+DFFF) to be encoded directly; these are prohibited in UTF-8. CESU-8, like UTF-8, encodes all 7-bit ASCII characters as-is which is convenient for C code.

I can't say I fully understand CESU-8, but it sounds we should always be transcoding Ruby Strings to UTF-8 before handing them off to Duktape. As for the returned object, they should either be tagged as UTF-8 or transcoded back to default internal/external (whatever one). I'd be fine with always having UTF-8 strings.

/cc @judofyr @brianmario
