### PR TITLE
Add option to skip ComplexObject values

### DIFF
--- a/test/test_duktape.rb
+++ b/test/test_duktape.rb
@@ -61,6 +61,11 @@ class TestDuktape < Minitest::Spec
         @ctx.eval_string('a = function() {}', __FILE__)
     end
 
+    def test_skip_complex_object
+      assert_equal nil,
+        @ctx.eval_string('a = function() {}', __FILE__, skip_complex: true)
+    end
+
     def test_reference_error
       assert_raises(Duktape::ReferenceError) do
         @ctx.eval_string('fail', __FILE__)


### PR DESCRIPTION
The new native return values work pretty nice in ExecJS, but I had to add some recursive discarding for the complex objects.

https://github.com/sstephenson/execjs/commit/a8a2d802690d104b5a5d2f27664ecbe98d3bdbf2#diff-bc43e6b021a91fde65d4936200f67d67R21

It'd be nice if this could just be ignored on eval with an optional flag. I'm not really sure what to call it, just posted a test like `skip_complex: true`.

The flag should really mean JSON values only. So whatever rules `JSON.stringify({a:1, b:function(){}})` uses to discard, this should do the same. Maybe `json_values: true`, `json_strict: true`, something like that?

No implementation yet, but what do you think about the feature?
