### PR TITLE
Set sDefaultFilename as a global

### DIFF
--- a/ext/duktape/duktape_ext.c
+++ b/ext/duktape/duktape_ext.c
@@ -556,7 +556,7 @@ void Init_duktape_ext()
 
   sDefaultFilename = rb_str_new2("(duktape)");
   OBJ_FREEZE(sDefaultFilename);
-  rb_ivar_set(mDuktape, rb_intern("default_filename"), sDefaultFilename);
+  rb_global_variable(&sDefaultFilename);
 }
 
 


### PR DESCRIPTION
Follow up to my concern on https://github.com/judofyr/duktape.rb/pull/25#issuecomment-84066138

A co-worker said `rb_global_variable` is the preferred way to define these globals for gc.

cc @judofyr 