### PR TITLE
allow to use FIXNUM above 2,147,483,647

### DIFF
--- a/ext/duktape/duktape_ext.c
+++ b/ext/duktape/duktape_ext.c
@@ -220,7 +220,7 @@ static void ctx_push_ruby_object(struct state *state, VALUE obj)
 
   switch (TYPE(obj)) {
     case T_FIXNUM:
-      duk_push_int(ctx, NUM2INT(obj));
+      duk_push_number(ctx, NUM2LONG(obj));
       return;
 
     case T_FLOAT:

--- a/test/test_duktape.rb
+++ b/test/test_duktape.rb
@@ -230,6 +230,7 @@ class TestDuktape < Minitest::Spec
 
     def test_fixnum
       assert_equal 2.0, @ctx.call_prop('id', 2)
+      assert_equal 1507843033737.0, @ctx.call_prop('id', 1507843033737)
     end
 
     def test_float


### PR DESCRIPTION
Fix issues like this one:
```
integer 1536598528930 too big to convert to `int'
```
