### PR TITLE
Fix result in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ require 'duktape'
 ctx = Duktape::Context.new
 
 ## Evaluate a string
-p ctx.eval_string('1 + 1')  # => 2
+p ctx.eval_string('1 + 1')  # => 2.0
 ```
 
 ### Contexts


### PR DESCRIPTION
```
$ ruby -v -rduktape -e 'ctx = Duktape::Context.new; p ctx.eval_string("1 + 1")'
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
2.0
```