### PR TITLE
Add call_iife method to call one-off IIFEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ JS
 ctx.call_prop('process', 'some data', a: 1, b: 2)
 ```
 
+You can also call IIFEs:
+
+``` ruby
+ctx = Duktape::Context.new
+
+ctx.call_prop('(function process(str, options) { /* ... */ })', 'some data', a: 1, b: 2)
+```
+
 ### Call APIs
 
 * `exec_string` - Evaluate a JavaScript String on the context and return `nil`.
@@ -51,6 +59,8 @@ ctx.call_prop('process', 'some data', a: 1, b: 2)
                   as a Ruby Object.
 - `call_prop`   - Call a defined function with the given parameters and return
                   the value as a Ruby Object.
+- `call_iife`   - Call an IIFE (Immediately Invoked Function Expression) and
+                  return the value as a Ruby Object.
 
 ### Defining functions
 

--- a/test/test_duktape.rb
+++ b/test/test_duktape.rb
@@ -378,6 +378,34 @@ class TestDuktape < Minitest::Spec
     end
   end
 
+  describe "#call_iife" do
+    def test_iife
+      assert_equal 'Hello world', @ctx.call_iife('(function(a) { return "Hello " + a })', 'world')
+    end
+
+    def test_syntax_error
+      assert_raises(Duktape::SyntaxError) do
+        @ctx.call_iife('(')
+      end
+    end
+
+    def test_not_a_function
+      assert_raises(Duktape::TypeError) do
+        @ctx.call_iife('123')
+      end
+    end
+
+    def test_invalid_argument
+      assert_raises(TypeError) do
+        @ctx.call_iife(123)
+      end
+
+      assert_raises(TypeError) do
+        @ctx.call_iife(nil)
+      end
+    end
+  end
+
   describe "#define_function" do
     def test_require_name
       err = assert_raises(ArgumentError) do


### PR DESCRIPTION
This allows safely passing Ruby values are arguments to IIFEs, e.g.

``` ruby
list = %w[foo bar]

ctx.call_iife(
  '(function(arr) { return arr.map(function(val) { return val.slice(1) }) })',
  list
) #=> ["oo", "ar"]
```